### PR TITLE
Remove reliance on refId

### DIFF
--- a/DumbView/format.py
+++ b/DumbView/format.py
@@ -69,17 +69,8 @@ def formatAlignedRead2(alnReader, refWindow, aln, useColor=False):
         elif x == "M":
             rendered += r
 
-    extras = ""
-    if alnReader.moviesAttached:
-        for snr in clippedRead.zmw.hqRegionSnr:
-            snrStr = " {:4.1f}".format(snr)
-            if snr < 4.0:
-                extras += red(snrStr)
-            else:
-                extras += snrStr
-
     startGap = clippedRead.tStart - refWindow.start
-    return " "*startGap + rendered + extras
+    return " "*startGap + rendered
 
 def formatUnalignedRead(alnReader, refWindow, aln, useColor=False):
     # FIXME!  This code is incorrect for reads that start partway through the window!

--- a/DumbView/main.py
+++ b/DumbView/main.py
@@ -17,7 +17,7 @@ def loadReferences(fastaFilename, alnReader):
 def dumpVariantCsv(fname, alnReader, alns, gffRecord, width=5):
     # Dump a CSV file for pulserecognizer with the following columns:
     # Movie,HoleNumber,rStart,rEnd
-    refId    = alnReader.referenceInfo(gffRecord.seqid).ID
+    refId    = gffRecord.seqid
     refStart = gffRecord.start - 1  # 1 to 0 based coordinates
     refEnd   = gffRecord.end
 
@@ -101,7 +101,7 @@ def mainGff(options):
         variantSummary = "(%s > %s)" % (referenceSeq, variantSeq)
         print gffRecord.type, gffRecord.seqid, gffRecord.start, gffRecord.end, \
             variantSummary, variantConfidence
-        refId = alnReader.referenceInfo(gffRecord.seqid).ID
+        refId = gffRecord.seqid
         refLength = alnReader.referenceInfo(gffRecord.seqid).Length
         refWindow = makeDisplayWindow(refLength, options.width,
                                        Window(refId,
@@ -137,7 +137,7 @@ def mainCmpH5(options):
         referenceTable = None
 
     for refWindow in options.referenceWindows:
-        refId = alnReader.referenceInfo(refWindow.refId).ID
+        refId = refWindow.refId
         refName = alnReader.referenceInfo(refWindow.refId).FullName
         refLength = alnReader.referenceInfo(refWindow.refId).Length
         refWindow = refWindow._replace(refId=refId)

--- a/DumbView/window.py
+++ b/DumbView/window.py
@@ -50,13 +50,15 @@ def makeDisplayWindow(contigLen, width, refWindow):
 
 def integerValue(s):
     try:
-        return int(s)
+        if s.isdigit():
+            return int(s)
     except:
-        return None
+        pass
+    return None
 
 def grok(s):
     iv = integerValue(s)
-    if integerValue is None:
+    if iv is None:
         return s
     else:
         return iv

--- a/tests/basics.t
+++ b/tests/basics.t
@@ -10,7 +10,7 @@
   $ [ -f $VARIANTS_GFF ] || echo "MISSING FILE"
   $ [ -f $CMPH5        ] || echo "MISSING FILE"
 
-  $ $DV $CMPH5 -w1:10 -W20
+  $ $DV $CMPH5 -wlambda_NEB3011:10 -W20
   lambda_NEB3011:1-19
                                
             ====+====|====+====
@@ -20,7 +20,7 @@
 
 
 
-  $ $DV $CMPH5 -w1:30900 -W20
+  $ $DV $CMPH5 -wlambda_NEB3011:30900 -W20
   lambda_NEB3011:30890-30909
                   30900         
             |====+====|====+====
@@ -33,7 +33,7 @@
 
 
 
-  $ $DV $CMPH5 -w1:30900 -W60
+  $ $DV $CMPH5 -wlambda_NEB3011:30900 -W60
   lambda_NEB3011:30870-30929
                   30880               30900               30920         
             |====+====|====+====|====+====|====+====|====+====|====+====


### PR DESCRIPTION
Replaced all instances of refId with refName.
- This does require that all windows specified use the reference name, rather
  than the refID.
- cmp.h5 and bam use 1 and 0 indexed refIds respectively anyway, so any built
  in converter would be ambiguous.

Updated test files
- basics.t now reflects the new window format
- All tests now pass

Removed deprecated hq region snr emission
- This is not implemented in DataSet and not supported by BAM

Fixed some utility functions
- Made the refName integer casting more restrictive, allowing string refNames
  to contain the occasional digit (as integer refNames are now the minority
  use case)
- Fixed a branch bug that unintentionally blocked string refNames.